### PR TITLE
docs: add missing npm install step to Part 1 client README

### DIFF
--- a/part1/client/README.md
+++ b/part1/client/README.md
@@ -4,12 +4,16 @@
 
 This is the client for the Getting Started section.  Before starting the client, make sure you start one of the servers found in section2 and section3.  You can start the client with the following:
 
-1.  Launch the client
-
+1. Install dependencies
 - In a terminal, navigate to the `part1/client` directory and run the following commands:
+```
+~/ai-for-devs/part1/client % npm install
+```
 
+2.  Launch the client
+- Afterwards, run following command:
 ```
 ~/ai-for-devs/part1/client % npm run dev
 ```
 
-2. Open your web browser and visit: http://localhost:5173
+3. Open your web browser and visit: http://localhost:5173


### PR DESCRIPTION
## What changed
The Part 1 client README was missing a step to install dependencies
before running the dev server. Following the instructions as written
on a fresh clone would fail at `npm run dev` with a "module not found"
error.

## Changes
- Added `npm install` as step 1 (before launching the client)
- Renumbered subsequent steps (Launch → step 2, Open browser → step 3)
- Fixed markdown spacing between sections for consistent rendering